### PR TITLE
Update Listener exceptions

### DIFF
--- a/dwm1001.py
+++ b/dwm1001.py
@@ -36,6 +36,10 @@ class ShellCommand(Enum):
     RESET = b"reset"
 
 
+class ParsingError(Exception):
+    pass
+
+
 class UartDwm1001:
     # These delay periods were experimentally determined
     RESET_DELAY_PERIOD = 0.1
@@ -93,8 +97,11 @@ class Listener(UartDwm1001):
     def wait_for_position_report(self) -> Tuple[TagId, TagPosition]:
         report = self.serial_handle.readline().decode().split(",")
 
-        if len(report) != 8 or report[0] != "POS":
-            raise ValueError("Could not parse position report.")
+        if len(report) != 8:
+            raise ParsingError("Position report has unexpected length.")
+
+        if report[0] != "POS":
+            raise ParsingError("Position report has incorrect tag.")
 
         position_data = [float(substr) for substr in report[3:6]]
         position_data.append(int(report[6]))

--- a/tests/test_dwm1001.py
+++ b/tests/test_dwm1001.py
@@ -73,14 +73,14 @@ class TestListener(unittest.TestCase):
         listener = dwm1001.Listener(serial_handle)
         listener.start_position_reporting()
 
-        self.assertRaises(ValueError, listener.wait_for_position_report)
+        self.assertRaises(dwm1001.ParsingError, listener.wait_for_position_report)
 
     def test_wait_for_position_report_wrong_header(self) -> None:
         serial_handle = MockSerial(b"BAD,1,TEST1,1.23,4.56,7.89")
         listener = dwm1001.Listener(serial_handle)
         listener.start_position_reporting()
 
-        self.assertRaises(ValueError, listener.wait_for_position_report)
+        self.assertRaises(dwm1001.ParsingError, listener.wait_for_position_report)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
The `Listener` class now raises a custom `ParsingError` exception when it cannot properly parse the position report. It also has different messages depending on the problem. The unit test have been updated.

Closes #9