### PR TITLE
Update Tag implementation

### DIFF
--- a/examples/print_tag_position.py
+++ b/examples/print_tag_position.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python3
+
+# Standard library imports
+from pathlib import Path
+import sys
+from typing import NoReturn
+
+# Third party imports
+from serial import Serial
+
+# Allows us to find dwm1001 library without installing it
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+import dwm1001
+
+
+def main() -> NoReturn:
+    serial_handle = Serial("/dev/ttyACM0", baudrate=115_200)
+    tag = dwm1001.Tag(serial_handle)
+    tag.start_position_reporting()
+
+    while True:
+        print(tag.position)
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pydwm1001"
-version = "0.1.1"
+version = "0.2.0"
 authors = [
   { name="Adam Morrissett", email="morrissettal2@vcu.edu" },
 ]


### PR DESCRIPTION
The Tag class now uses the UartDwm1001 base class, which improves interfacing. An example script has also been provided. The new version is 0.2.0 since this is significant change.

Closes #15 