### PR TITLE
Rename almost_equal function

### DIFF
--- a/dwm1001.py
+++ b/dwm1001.py
@@ -20,7 +20,7 @@ class TagPosition:
     z_m: float
     quality: int
 
-    def almost_equal(self, other: "TagPosition") -> bool:
+    def is_almost_equal(self, other: "TagPosition") -> bool:
         return (
             math.isclose(self.x_m, other.x_m)
             and math.isclose(self.y_m, other.y_m)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pydwm1001"
-version = "0.6.0"
+version = "0.7.0"
 authors = [
   { name="Adam Morrissett", email="morrissettal2@vcu.edu" },
 ]

--- a/tests/test_dwm1001.py
+++ b/tests/test_dwm1001.py
@@ -45,7 +45,7 @@ class TestTagPosition(unittest.TestCase):
         position1 = dwm1001.TagPosition(1.23, 4.56, 7.89, 42)
         position2 = dwm1001.TagPosition(1.23, 4.56, 7.89, 42)
 
-        self.assertTrue(position1.almost_equal(position2))
+        self.assertTrue(position1.is_almost_equal(position2))
 
 
 class TestPassiveTag(unittest.TestCase):
@@ -66,7 +66,7 @@ class TestPassiveTag(unittest.TestCase):
         self.assertEqual(tag_id, "TEST1")
 
         expected_position = dwm1001.TagPosition(1.23, 4.56, 7.89, 20)
-        self.assertTrue(tag_position.almost_equal(expected_position))
+        self.assertTrue(tag_position.is_almost_equal(expected_position))
 
     def test_wait_for_position_report_short(self) -> None:
         serial_handle = MockSerial(b"POS,1,TEST1,1.23,4.56,7.89")


### PR DESCRIPTION
The function was renamed to is_almost_equal to unify query-type function names with is_, has_, should_, ... prefixes.

Closes #21 