### PR TITLE
Update UartDwm1001 properties

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pydwm1001"
-version = "0.7.0"
+version = "0.8.0"
 authors = [
   { name="Adam Morrissett", email="morrissettal2@vcu.edu" },
 ]


### PR DESCRIPTION
The tag_id property now returns the full UWB identifier for the tag. The tag_name property returns "DW" plus the last four UWB identifier digits. The tag_name property is the same as the value shown on the DWM1001 Android app.

Closes #28