### PR TITLE
Add generic device response getter

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pydwm1001"
-version = "0.8.0"
+version = "0.9.0"
 authors = [
   { name="Adam Morrissett", email="morrissettal2@vcu.edu" },
 ]


### PR DESCRIPTION
The response getter function will read until it finds the shell prompt, indicating that the response is finished. The `tag_id` property implementation has been updated to use the new getter.

Closes #23 