### PR TITLE
Rename tag_id to uwb_address

### DIFF
--- a/dwm1001.py
+++ b/dwm1001.py
@@ -35,7 +35,7 @@ class TagPosition:
 
 @dataclass
 class SystemInfo:
-    address: int
+    uwb_address: int
 
 
 class ShellCommand(Enum):
@@ -62,10 +62,10 @@ class UartDwm1001:
     @property
     def tag_name(self) -> TagName:
         # We only use the last four characters in the address
-        return TagName("DW" + self.tag_id[-4:])
+        return TagName("DW" + self.uwb_address[-4:])
 
     @property
-    def tag_id(self) -> TagId:
+    def uwb_address(self) -> TagId:
         self.send_shell_command(ShellCommand.SI)
 
         response = self.get_shell_response().splitlines()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pydwm1001"
-version = "0.9.0"
+version = "0.10.0"
 authors = [
   { name="Adam Morrissett", email="morrissettal2@vcu.edu" },
 ]


### PR DESCRIPTION
The `tag_id` property represented what the DWM1001's system information calls the UWB address.

Closes #30