### PR TITLE
Add system_info property, remove label

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pydwm1001"
-version = "0.10.0"
+version = "0.11.0"
 authors = [
   { name="Adam Morrissett", email="morrissettal2@vcu.edu" },
 ]


### PR DESCRIPTION
The label property has been removed and replaced by the system_info property. The system_info property returns a SystemInfo object, which contains the DWM1001 device's label. This will keep the UartDwm1001 class lean because it avoids duplicated functionality.

Closes #31 