### PR TITLE
Replace `removeprefix` function

### DIFF
--- a/dwm1001.py
+++ b/dwm1001.py
@@ -44,13 +44,11 @@ class SystemInfo:
 
         uwb_address_line = data_lines[1].strip()
         address_text_start = uwb_address_line.find("addr=")
-        address_string = "0" + uwb_address_line[address_text_start:].removeprefix(
-            "addr="
-        )
+        address_string = "0" + uwb_address_line[address_text_start + len("addr=") :]
 
         label_line = data_lines[5].strip()
         label_text_start = label_line.find("label=")
-        label_string = label_line[label_text_start:].removeprefix("label=")
+        label_string = label_line[label_text_start + len("label=") :]
 
         return SystemInfo(uwb_address=address_string, label=label_string)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pydwm1001"
-version = "0.12.0"
+version = "0.12.1"
 authors = [
   { name="Adam Morrissett", email="morrissettal2@vcu.edu" },
 ]


### PR DESCRIPTION
The `removeprefix` function has been replaced with a hard-coded index offset. Since we know the tag address and label and strings start with the "addr=" and "label=" prefixes, respectively, it shouldn't be an issue that we jump by those strings' lengths.

Closes #38